### PR TITLE
Remove tutorial on startup

### DIFF
--- a/src/main/java/duke/javafx/MainWindow.java
+++ b/src/main/java/duke/javafx/MainWindow.java
@@ -41,10 +41,8 @@ public class MainWindow extends AnchorPane {
         duke = d;
         assert duke != null;
         String greeting = duke.getGreeting();
-        String tutorial = duke.getTutorial();
         DialogBox dbGreeting = DialogBox.getDukeDialog(greeting, dukeImage);
-        DialogBox dbTutorial = DialogBox.getDukeDialog(tutorial, dukeImage);
-        dialogContainer.getChildren().addAll(dbGreeting, dbTutorial);
+        dialogContainer.getChildren().addAll(dbGreeting);
     }
 
     /**

--- a/src/main/java/duke/main/Duke.java
+++ b/src/main/java/duke/main/Duke.java
@@ -58,13 +58,4 @@ public class Duke {
     public String getGreeting() {
         return ui.showGreeting();
     }
-
-    /**
-     * Returns tutorial message
-     *
-     * @return String tutorial message
-     */
-    public String getTutorial() {
-        return ui.showTutorial();
-    }
 }


### PR DESCRIPTION
Duke shows the feature list at start up and it fills up the whole screen. The feature list belongs on the user manual so let's remove that.